### PR TITLE
add version to template loader

### DIFF
--- a/prompt_poet/prompt.py
+++ b/prompt_poet/prompt.py
@@ -259,6 +259,11 @@ class Prompt:
         return self._template.template_id
 
     @property
+    def template_version(self) -> str:
+        """The version of the template associated with the template loader."""
+        return self._template.template_version
+
+    @property
     def template_package_name(self) -> str:
         """The metadata associated with the template."""
         return self._template.template_package_name

--- a/prompt_poet/template.py
+++ b/prompt_poet/template.py
@@ -135,6 +135,11 @@ class Template:
         """The id of the template associated with the template loader."""
         return self._template_loader.id()
 
+    @property
+    def template_version(self) -> str:
+        """The version of the template associated with the template loader."""
+        return self._template_loader.version()
+
     def _load_template(self):
         """Load a jinja2 template."""
         if self._raw_template:


### PR DESCRIPTION
This can be useful to track how many of the workers had the up-to-date templates from GCS etc.