### PR TITLE
Fix: Allow `Prompt` to accept raw templates without requiring `template_path`

### DIFF
--- a/prompt_poet/prompt.py
+++ b/prompt_poet/prompt.py
@@ -106,6 +106,7 @@ class Prompt:
         allow_token_overrides: bool = False,
     ):
         """Initialize the prompt object."""
+        template_path = template_path or ""
         self._template = Template(
             template_path=template_path,
             package_name=package_name,

--- a/prompt_poet/prompt.py
+++ b/prompt_poet/prompt.py
@@ -483,9 +483,10 @@ class Prompt:
                 raise ValueError(f"Missing replacement values for keys: {missing_keys=} {part=}")
 
     def _cleanup_content(self, part: PromptPart):
-        """Remove whitespace and unescape special characters, if present."""
-        content = part.content.strip().replace(self._space_marker, " ")
-        part.content = self._unescape_special_characters(content)
+        """Safely handle content that may be non-string (e.g., dict)."""
+        if isinstance(part.content, str):
+            content = part.content.strip().replace(self._space_marker, " ")
+            part.content = self._unescape_special_characters(content)
 
     def _escape_special_characters(self, string: str) -> str:
         """Escape sequences that will break yaml parsing."""


### PR DESCRIPTION
This PR resolves two key issues that arise when initializing a `Prompt` with only a `raw_template`:

1. **Defaulting `template_path`**:
   Sets `template_path = ""` when not provided, avoiding a `TypeError` from `os.path.split()` which expects a string.

2. **Content Cleanup Safety**:
   Updates `_cleanup_content()` to guard against non-string `content` values (e.g., `dict`), preventing `AttributeError` during `.strip()`.

These changes improve flexibility for constructing prompts directly from strings and support structured content (like multi-modal inputs) safely.